### PR TITLE
Completing PATCH request for /api/articles/:article_id

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,6 +6,7 @@ const {
   getArticles,
   getCommentFromArticleID,
   postNewComment,
+  addArticleVotes,
 } = require("./controllers/api.controllers");
 const { getEndpoints } = require("./controllers/endpoints.controllers");
 
@@ -17,6 +18,7 @@ app.get("/api/articles/:article_id", getArticlesById);
 app.get("/api/articles", getArticles);
 app.get("/api/articles/:article_id/comments", getCommentFromArticleID);
 app.post("/api/articles/:article_id/comments", postNewComment);
+app.patch("/api/articles/:article_id", addArticleVotes);
 
 app.all("*", (req, res) => {
   res.status(404).send({ msg: "Route not found" });

--- a/endpoints.json
+++ b/endpoints.json
@@ -64,18 +64,37 @@
       }
     ]
   },
-    "POST /api/articles/:article_id/comments": {
+  "POST /api/articles/:article_id/comments": {
     "description": "serves the comments on the requested article",
     "queries": [],
-    "exampleResponse": [
-      {
-        "comment_id": 1,
-        "body": "Oh, I've got compassion running out of my nose, pal! I'm the Sultan of Sentiment!",
-        "votes": 16,
-        "author": "butter_bridge",
-        "article_id": 9,
-        "created_at": "2018-05-30T15:59:13.341Z"
-      }
-    ]
+    "exampleBody": {
+      "username": "butter_bridge",
+      "body": "Oh, I've got compassion running out of my nose, pal! I'm the Sultan of Sentiment!"
+    },
+    "exampleResponse": {
+      "comment_id": 1,
+      "body": "Oh, I've got compassion running out of my nose, pal! I'm the Sultan of Sentiment!",
+      "votes": 16,
+      "author": "butter_bridge",
+      "article_id": 9,
+      "created_at": "2018-05-30T15:59:13.341Z"
+    }
+  },
+  "PATCH /api/articles/:article_id": {
+    "description": "adds to an article's votes property by a given amount",
+    "queries": [],
+    "exampleBody": {
+      "inc_votes": 10
+    },
+    "exampleResponse": {
+      "article_id": 1,
+      "title": "Living in the shadow of a great man",
+      "topic": "mitch",
+      "author": "butter_bridge",
+      "body": "I find this existence challenging",
+      "created_at": "2020-07-09T20:11:00.000Z",
+      "votes": 110,
+      "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
+    }
   }
 }


### PR DESCRIPTION
- Went back and improved testing for GET /api/articles/:article_id/comments and POST /api/articles/:article_id/comments
- For GET /api/articles/:article_id/comments I introduced testing for if there is a valid ID but no comments (returns an empty array) and also testing for if an invalid ID is passed
- I approached the issue of how to know why a query is returning empty rows by invoking `selectArticleById(article_id)` which will check if the article id is valid or not. If it does exist it will move onto `return data.rows` which will mean that the article does exist it just has no comments
- For POST /api/articles/:article_id/comments I moved some of my logic from the controller to the model and got rid of some error handling that wasn't needed 
- Then created an endpoint for /api/articles/:article_id which responds with an updated article by adding to an articles votes property by a given amount
- Added various error handling for this, such as if the article doesn't exist, if inc_votes is not set, if the new votes are less than zero, if inc_votes is not a number and if the id is valid. I also checked that votes can be successfully added and subtracted
- I then went back and used `selectArticleById(article_id)` on everything that tries to access an article id to check that the article id is valid
- I then added some logic to my GET /api endpoint to test that if my endpoint documentation includes an example body (I added this in my POST and PATCH documentation) that it would be an object