### PR TITLE
Completing DELETE request for /api/comments/:comment_id

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -391,3 +391,22 @@ describe("PATCH /api/articles/:article_id", () => {
       });
   });
 });
+
+describe("DELETE /api/comments/:comment_id", () => {
+  test("204: Responds with no content if successfully deleted", () => {
+    return request(app)
+      .delete("/api/comments/1")
+      .expect(204)
+      .then(({ body }) => {
+        expect(body).toEqual({});
+      });
+  });
+  test("400: Responds with an error message if the comment_id is invalid", () => {
+    return request(app)
+      .delete("/api/comments/1000")
+      .expect(404)
+      .then(({ body }) => {
+        expect(body.msg).toEqual("Not found");
+      });
+  });
+});

--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ const {
   getCommentFromArticleID,
   postNewComment,
   addArticleVotes,
+  deleteComment,
 } = require("./controllers/api.controllers");
 const { getEndpoints } = require("./controllers/endpoints.controllers");
 
@@ -19,6 +20,7 @@ app.get("/api/articles", getArticles);
 app.get("/api/articles/:article_id/comments", getCommentFromArticleID);
 app.post("/api/articles/:article_id/comments", postNewComment);
 app.patch("/api/articles/:article_id", addArticleVotes);
+app.delete("/api/comments/:comment_id", deleteComment)
 
 app.all("*", (req, res) => {
   res.status(404).send({ msg: "Route not found" });

--- a/controllers/api.controllers.js
+++ b/controllers/api.controllers.js
@@ -4,6 +4,7 @@ const {
   selectCommentFromArticleID,
   postCommentOnArticle,
   changeArticleVotes,
+  removeComment
 } = require("../models/articles.models");
 const { selectTopics } = require("../models/topics.model");
 
@@ -98,6 +99,16 @@ exports.addArticleVotes = (req, res, next) => {
         .catch((err) => {
           next(err);
         });
+    })
+    .catch((err) => {
+      next(err);
+    });
+};
+
+exports.deleteComment = (req, res, next) => {
+  removeComment(req.params.comment_id)
+    .then(() => {
+      res.status(204).send();
     })
     .catch((err) => {
       next(err);

--- a/endpoints.json
+++ b/endpoints.json
@@ -96,5 +96,10 @@
       "votes": 110,
       "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
     }
+  },
+  "DELETE /api/comments/:comment_id": {
+    "description": "deletes the requested comment",
+    "queries": [],
+    "exampleResponse": {}
   }
 }

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -98,3 +98,16 @@ exports.changeArticleVotes = (article_id, votes) => {
       return rows[0];
     });
 };
+
+exports.removeComment = (comment_id) => {
+  return db
+    .query(`DELETE FROM comments WHERE comment_id = $1 RETURNING *;`, 
+    [comment_id]).then((res) => {
+      if (res.rowCount === 0) {
+        return Promise.reject({
+          status: 404,
+          msg: "Not found",
+        });
+      }
+    });
+};


### PR DESCRIPTION
- Created an endpoint for /api/comments/:comment_id which responds with 204 and no content once the comment has been deleted by the given comment id
- Looked at the row count from the database response to see if any rows were deleted, if this was 0, then I returned a 404 error message
- Updated the endpoints.json