### PR TITLE
Completing topic query for /api/articles

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -176,6 +176,44 @@ describe("GET /api/articles", () => {
         expect(body.msg).toBe("Invalid order");
       });
   });
+  test("200: topic query; returns an array of article objects that have the requested topic", () => {
+    return request(app)
+      .get("/api/articles?topic=mitch")
+      .expect(200)
+      .then(({ body }) => {
+        const { articles } = body;
+        expect(articles).toHaveLength(12);
+      });
+  });
+  test("200: topic query and SORT BY query; returns an array of article objects that have the requested topic sorted by title", () => {
+    return request(app)
+      .get("/api/articles?topic=mitch&sort_by=title")
+      .expect(200)
+      .then(({ body }) => {
+        const { articles } = body;
+        expect(articles).toHaveLength(12);
+        expect(articles).toBeSortedBy("title", {
+          descending: true,
+        });
+      });
+  });
+  test("200: topic query; returns an empty array when the topic has no articles", () => {
+    return request(app)
+      .get("/api/articles?topic=paper")
+      .expect(200)
+      .then(({ body }) => {
+        const { articles } = body;
+        expect(articles).toHaveLength(0);
+      });
+  });
+  test("400: topic query; returns an error when passed a topic that is an empty string", () => {
+    return request(app)
+      .get("/api/articles?topic=")
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toEqual("topic cannot be an empty string");
+      });
+  });
 });
 
 describe("GET /api/articles/:article_id/comments", () => {

--- a/controllers/api.controllers.js
+++ b/controllers/api.controllers.js
@@ -33,8 +33,8 @@ exports.getArticlesById = (req, res, next) => {
 };
 
 exports.getArticles = (req, res, next) => {
-  const { sort_by, order } = req.query;
-  selectArticles(sort_by, order)
+  const { sort_by, order, topic } = req.query;
+  selectArticles(sort_by, order, topic)
     .then((articles) => {
       res.status(200).send({ articles });
     })

--- a/endpoints.json
+++ b/endpoints.json
@@ -20,7 +20,7 @@
     }
   },
   "GET /api/articles": {
-    "description": "serves an array of all articles",
+    "description": "serves an array of all articles optionally filtered by topic",
     "queries": ["author", "topic", "sort_by", "order"],
     "exampleResponse": {
       "articles": [

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -17,12 +17,7 @@ exports.selectArticleById = (article_id) => {
     });
 };
 
-exports.selectArticles = (sort_by = "created_at", order = "DESC") => {
-  const sqlQuery = `SELECT articles.author, articles.title, articles.article_id, articles.topic, articles.created_at, articles.votes, articles.article_img_url, count(*) as comment_count FROM articles
-LEFT JOIN comments ON comments.article_id = articles.article_id
-  GROUP BY articles.article_id
-  ORDER BY articles.${sort_by} ${order}`;
-
+exports.selectArticles = (sort_by = "created_at", order = "DESC", topic) => {
   const validOrderByQueries = ["ASC", "DESC"];
 
   if (!validOrderByQueries.includes(order.toUpperCase())) {
@@ -42,6 +37,20 @@ LEFT JOIN comments ON comments.article_id = articles.article_id
   if (!validSortByQueries.includes(sort_by)) {
     return Promise.reject({ status: 400, msg: "Invalid sort_by" });
   }
+
+  let sqlQuery = `SELECT articles.author, articles.title, articles.article_id, articles.topic, articles.created_at, articles.votes, articles.article_img_url, count(*) as comment_count
+  FROM articles
+  LEFT JOIN comments ON comments.article_id = articles.article_id`;
+
+  if (topic !== undefined) {
+    if (topic.length === 0) {
+      return Promise.reject({status: 400, msg: "topic cannot be an empty string"})
+    }
+
+    sqlQuery += ` WHERE topic = '${topic}'`;
+  }
+
+  sqlQuery += ` GROUP BY articles.article_id ORDER BY articles.${sort_by} ${order}`;
 
   return db
     .query(sqlQuery)


### PR DESCRIPTION
- Added a topic query to /api/articles which filters the articles by the topic specified in the query 
- Added testing to see if the topic exists, and if it does, check that it is not an empty string 